### PR TITLE
Tidy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # StrEnum.AspNetCore
 
-Allows to use [StrEnum](https://github.com/StrEnum/StrEnum/) string enums with ASP.NET Core.
+Lets you use [StrEnum](https://github.com/StrEnum/StrEnum/) string enums with ASP.NET Core.
 
-Supports ASP.NET Core 6-10.
-
-ASP.NET Core 5 supported in v2.0.0.
+Supports ASP.NET Core 6 – 10. For ASP.NET Core 5, use v2.0.0.
 
 ## Installation
 
-You can install [StrEnum.AspNetCore](https://www.nuget.org/packages/StrEnum.AspNetCore/) using the .NET CLI:
+Install [StrEnum.AspNetCore](https://www.nuget.org/packages/StrEnum.AspNetCore/) via the .NET CLI:
 
 ```
 dotnet add package StrEnum.AspNetCore
@@ -16,7 +14,9 @@ dotnet add package StrEnum.AspNetCore
 
 ## Usage
 
-If you're using `WebApplicationBuilder`,  add the call to `AddStringEnums()` into your `Program.cs`:
+### Registering the binder
+
+If you're using `WebApplicationBuilder`, call `AddStringEnums()` in `Program.cs`:
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
@@ -26,18 +26,18 @@ builder.Services
     .AddStringEnums();
 ```
 
-If you're using the ASP.NET Core 3.1-5 `IWebHostBuilder`, call `AddStringEnums()` in the `ConfigureServices` method of your `Startup.cs`:
+For the ASP.NET Core 3.1–5 `IWebHostBuilder`, call `AddStringEnums()` in `ConfigureServices` in `Startup.cs`:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-     services
-         .AddControllers()
-         .AddStringEnums();
+    services
+        .AddControllers()
+        .AddStringEnums();
 }
 ```
 
-All set. Let's now create a string enum and a model that contains it:
+### Defining a string enum and a model
 
 ```csharp
 public class Sport : StringEnum<Sport>
@@ -53,39 +53,41 @@ public class Race
 }
 ```
 
-You can bind string enums to the request body and return them in the response. In your controller, add the following:
+### Binding string enums in controllers
+
+Bind from the request body and serialize them back in the response:
 
 ```csharp
 [HttpPost]
-public ActionResult<Race> BodyPost([FromBody] Race race) // race.Sport is correctly deserialized
+public ActionResult<Race> BodyPost([FromBody] Race race) // race.Sport is deserialized correctly
 {
     return Ok(race); // race.Sport is serialized back
 }
 ```
 
-You can also bind string enums to a URL:
+Bind from a route parameter:
 
 ```csharp
 [HttpGet]
 [Route("{sport}")]
-public ActionResult<ResponseWithStrEnum> GetFromRoute(Sport sport) {...}
+public ActionResult<ResponseWithStrEnum> GetFromRoute(Sport sport) { ... }
 ```
 
-To a query string parameter:
+Bind from a query string parameter:
 
 ```csharp
 [HttpGet]
 [Route("get")]
-public ActionResult<ResponseWithStrEnum> GetFromQuery([FromQuery]Sport sport) {...}
+public ActionResult<ResponseWithStrEnum> GetFromQuery([FromQuery] Sport sport) { ... }
 // `get?sport=trail_running` binds to Sport.TrailRunning
 ```
 
-And to an array of query string parameters:
+Bind to an array of query string parameters:
 
 ```csharp
 [HttpGet]
 [Route("get")]
-public ActionResult<ResponseWithStrEnum> GetFromQuery([FromQuery] Sport[] sports) {...}
+public ActionResult<ResponseWithStrEnum> GetFromQuery([FromQuery] Sport[] sports) { ... }
 // `get?sports=trail_running&sports=road_cycling` binds to [Sport.TrailRunning, Sport.RoadCycling]
 ```
 


### PR DESCRIPTION
## Summary
- Same readability pass applied across the StrEnum family ([StrEnum](https://github.com/StrEnum/StrEnum/pull/12), [StrEnum.EntityFrameworkCore](https://github.com/StrEnum/StrEnum.EntityFrameworkCore/pull/7)). No code changes, README copy only.
- Adds three sub-headings inside **Usage** so the section isn't a single wall of prose:
  - `### Registering the binder`
  - `### Defining a string enum and a model`
  - `### Binding string enums in controllers`
- Style tweaks: `Allows to use` → `Lets you use`; `Supports ASP.NET Core 6-10` → `Supports ASP.NET Core 6 – 10` (consistent en-dash spacing); the v2.0.0 footnote is folded into the same line; `You can install ... using` → `Install ... via`; fixes the double-space typo in `If you're using WebApplicationBuilder,  add the call`; tightens the awkward "add the call to ... into your `Program.cs`" → "call ... in `Program.cs`".
- Code samples: fixes `[FromQuery]Sport` (missing space), `{...}` → `{ ... }`, and the 5-space indent in the `Startup.cs` snippet → 4-space.

## Test plan
- [x] Render the README to verify formatting and the new sub-headings
- [x] Confirm code samples still compile-look correct (no logic changes)